### PR TITLE
注文番号の生成ロジックを修正

### DIFF
--- a/app/config/eccube/packages/eccube.yaml
+++ b/app/config/eccube/packages/eccube.yaml
@@ -97,6 +97,13 @@ parameters:
     eccube_reset_complete_mail_template_id: 7 #パスワードリマインダー
     eccube_shipping_notify_mail_template_id: 8 #出荷通知メール
     eccube_package_repo_url: null
-    # {yyyy} : 西暦(4桁)、{yy} : 西暦(下2桁)、{mm} : 月(09)、{dd} : 日(01)、{id,桁数} : dtb_order.idの桁数分0埋め(桁数を超えたらそのまま表示)
-    # {random,桁数]} : ランダムな数値を桁数分作成(9桁まで対応)、{randomalphanum,桁数]} : ランダムな半角英数大文字を桁数分作成
-    eccube_order_no_format: '{dd}{yyyy}{id,5}{mm}' # フォーマットに何も設定しなければ、dtb_order.id がそのまま設定される
+    # 注文番号のフォーマット. 以下のフォーマットが利用可能です. フォーマットを空にした場合, dtb_order.idを出力します.
+    # {yyyy} : 西暦(4桁)
+    # {yy}: 西暦(2桁)
+    # {mm}: 月(09)
+    # {dd}: 日(01)
+    # {id,桁数}: dtb_order.idの桁数分0埋め(桁数を超えたらそのまま表示)
+    # {random,桁数}: ランダムな数値を桁数分作成
+    # {random_alnum,桁数} : ランダムな半角英数大文字を桁数分作成
+    eccube_order_no_format: '{dd}{yyyy}{id,9}{mm}'
+

--- a/src/Eccube/Service/PurchaseFlow/Processor/OrderNoProcessor.php
+++ b/src/Eccube/Service/PurchaseFlow/Processor/OrderNoProcessor.php
@@ -64,7 +64,7 @@ class OrderNoProcessor implements PurchaseProcessor
             } else {
                 do {
                     $orderNo = preg_replace_callback('/\{(.*)}/U', function ($matches) use ($Order) {
-                        if (count($matches) == 2) {
+                        if (count($matches) === 2) {
                             switch ($matches[1]) {
                                 case 'yyyy':
                                     return date('Y');
@@ -75,24 +75,24 @@ class OrderNoProcessor implements PurchaseProcessor
                                 case 'dd':
                                     return date('d');
                                 default:
-                                    $res = explode(',', $matches[1]);
-                                    if (count($res) == 2 && is_numeric($res[1])) {
-                                        if ($res[0] == 'id') {
+                                    $res = explode(',', str_replace(' ', '', $matches[1]));
+                                    if (count($res) === 2 && is_numeric($res[1])) {
+                                        if ($res[0] === 'id') {
                                             return sprintf("%0{$res[1]}d", $Order->getId());
-                                        } elseif ($res[0] == 'random') {
-                                            $rondom = substr(mt_rand(1, 999999999), 0, $res[1]);
+                                        } elseif ($res[0] === 'random') {
+                                            $random = random_int(1, (int)str_repeat('9', $res[1]));
 
-                                            return sprintf("%0{$res[1]}d", $rondom);
-                                        } elseif ($res[0] == 'randomalphanum') {
-                                            return strtoupper(StringUtil::random(5));
+                                            return sprintf("%0{$res[1]}d", $random);
+                                        } elseif ($res[0] === 'random_alnum') {
+                                            return strtoupper(StringUtil::random($res[1]));
                                         }
                                     }
 
-                                    return '';
+                                    return $Order->getId();
                             }
                         }
 
-                        return '';
+                        return $Order->getId();
                     }, $format);
 
                     $tempOrder = $this->orderRepository->findOneBy([

--- a/src/Eccube/Service/PurchaseFlow/Processor/OrderNoProcessor.php
+++ b/src/Eccube/Service/PurchaseFlow/Processor/OrderNoProcessor.php
@@ -80,7 +80,7 @@ class OrderNoProcessor implements PurchaseProcessor
                                         if ($res[0] === 'id') {
                                             return sprintf("%0{$res[1]}d", $Order->getId());
                                         } elseif ($res[0] === 'random') {
-                                            $random = random_int(1, (int)str_repeat('9', $res[1]));
+                                            $random = random_int(1, (int) str_repeat('9', $res[1]));
 
                                             return sprintf("%0{$res[1]}d", $random);
                                         } elseif ($res[0] === 'random_alnum') {


### PR DESCRIPTION
- 初期フォーマットのコメントが読みづらかったので修正
- フォーマットのIDの桁数を9桁に
- 重複した場合はdtb_order.idを返す
- randomalphanumがtypoしそうなので, random_alnumに変更
